### PR TITLE
Decode '+' as space when parsing URLSearchParams

### DIFF
--- a/lib/url-search-params.js
+++ b/lib/url-search-params.js
@@ -151,8 +151,12 @@ class URLSearchParams {
       let i = sequence.indexOf('=')
       if (i === -1) i = sequence.length
 
-      const name = decodeURIComponent(sequence.substring(0, i))
-      const value = decodeURIComponent(sequence.substring(i + 1, sequence.length))
+      // application/x-www-form-urlencoded parser: replace '+' with space (0x20)
+      // before percent-decoding (https://url.spec.whatwg.org/#urlencoded-parsing).
+      const name = decodeURIComponent(sequence.substring(0, i).replace(/\+/g, ' '))
+      const value = decodeURIComponent(
+        sequence.substring(i + 1, sequence.length).replace(/\+/g, ' ')
+      )
 
       let list = this._params.get(name)
 

--- a/test.js
+++ b/test.js
@@ -404,3 +404,21 @@ test('format', (t) => {
     'https://example.com/some/path?page=1&format=json'
   )
 })
+
+test("URLSearchParams parse decodes '+' as space", (t) => {
+  const params = new URLSearchParams('q=hello+world&k=a%2Bb')
+  t.is(params.get('q'), 'hello world')
+  t.is(params.get('k'), 'a+b')
+})
+
+test("URL.searchParams decodes '+' as space", (t) => {
+  const url = new URL('http://example.com/?q=hello+world')
+  t.is(url.searchParams.get('q'), 'hello world')
+})
+
+test("URLSearchParams round-trip preserves literal '+' in values", (t) => {
+  const params = new URLSearchParams()
+  params.set('v', 'a+b')
+  t.is(params.toString(), 'v=a%2Bb')
+  t.is(new URLSearchParams(params.toString()).get('v'), 'a+b')
+})


### PR DESCRIPTION
## Summary

`URLSearchParams._parse` currently passes each name/value directly to `decodeURIComponent`, so the `+` → space substitution required by the `application/x-www-form-urlencoded` parser is skipped. That step is mandated by [WHATWG URL §5.1, step 3.3](https://url.spec.whatwg.org/#urlencoded-parsing):

> If byte is 0x2B (+), then set byte to 0x20 (SP).

This made Bare's `URLSearchParams` diverge from Node, Deno, Bun, and browsers, and made it internally inconsistent with its own serializer (`_serialize` already encodes literal `+` as `%2B`).

### Before

```js
new URLSearchParams('q=hello+world').get('q')   // 'hello+world'  (wrong)
new URL('http://x/?q=a+b').searchParams.get('q') // 'a+b'         (wrong)

const p = new URLSearchParams()
p.set('v', 'a+b')
p.toString()                                     // 'v=a%2Bb'
new URLSearchParams(p.toString()).get('v')       // 'a+b' (round-trip OK only by coincidence)
new URLSearchParams('v=a+b').get('v')            // 'a+b' (should be 'a b')
```

### After

```js
new URLSearchParams('q=hello+world').get('q')    // 'hello world'
new URLSearchParams('v=a%2Bb').get('v')          // 'a+b'
new URLSearchParams('?a+b=c+d')                  // [['a b', 'c d']]
```

Matches Node's `URLSearchParams` byte-for-byte on the cases I tested.

## Change

`lib/url-search-params.js` — replace `+` with ` ` on each name/value substring before percent-decoding, per spec.

## Tests

Added three regression tests in `test.js`:
- `URLSearchParams` parse decodes `+` as space (and leaves `%2B` as literal `+`)
- `URL.searchParams` decodes `+` as space (covers the path through `URL`)
- Round-trip of a value containing literal `+` is stable (`'a+b'` → `'v=a%2Bb'` → `'a+b'`)

## Notes

- The fix is two `.replace(/\+/g, ' ')` calls; no other behavior changes.
- I wasn't able to run `bare test.js` locally (the `cmake_minimum_required(VERSION 4.0)` in `CMakeLists.txt` exceeds my installed CMake 3.27, so the native binding wouldn't build), but `lib/url-search-params.js` is pure JS and I verified all three new test cases pass against it via Node, with output identical to Node's built-in `URLSearchParams`.

Found while debugging spurious test failures on Bare in [`bare-mcp`](https://github.com/CameronTofer/bare-mcp) where URI-template query parsing diverged between Node and Bare for the same input.

Made with [Cursor](https://cursor.com)